### PR TITLE
A tiny typo correction on English home page

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -62,7 +62,7 @@
     "nav.developers": "Developers",
     "nav.title": "Secure digital assets and messages on Mixin",
     "nav.description1": "We build open source software",
-    "nav.description2": "that always put security, privacy and",
+    "nav.description2": "that always puts security, privacy and",
     "nav.description3": " decentralization at first.",
     "section.network": "A free and lightning fast peer-to-peer transactional network for digital assets.",
     "section.messenger": "An open source cryptocurrency wallet with Signal messaging.",


### PR DESCRIPTION
Just found a tiny error on the English landing page: "We build open source software that always **put** security, privacy and decentralization at first." 
Grammatically, it seems that the verb **_put_** should agree with the uncountable subject "open-source software" by using the verb-form "**puts**"

Cheers,
D 
